### PR TITLE
Device class is now more testable

### DIFF
--- a/Framework/Dotzu/Dotzu/Device.swift
+++ b/Framework/Dotzu/Dotzu/Device.swift
@@ -9,13 +9,11 @@
 import UIKit
 
 struct Device {
-    var osVersion: String?
-    var screenResolution: String!
     let deviceModel: DeviceModel = DeviceModel.current
     
-    var getScreenSize: String?
+    var osVersion: String?
+    var screenResolution: String!
     var aspectRatio: String?
-    
     var screenSize: Float!
     
     init() {

--- a/Framework/Dotzu/Dotzu/Device.swift
+++ b/Framework/Dotzu/Dotzu/Device.swift
@@ -9,19 +9,27 @@
 import UIKit
 
 struct Device {
-
     var osVersion: String?
-    static var screenResolution: String? {
+    var screenResolution: String?
+    let deviceModel: DeviceModel = DeviceModel.current
+    
+    var getScreenSize: String?
+    var aspectRatio: String?
+    
+    var screenSize: Float!
+    
+    init() {
+        self.screenResolution = self.deviceScreenResolution()
+        self.screenSize = self.deviceScreenSize()
+    }
+    
+    private func deviceScreenResolution() -> String {
         let scale = UIScreen.main.scale
         let dimension = UIScreen.main.bounds
         return "\(dimension.size.width*scale)*\(dimension.size.height*scale)"
     }
-    static var deviceModel: DeviceModel = DeviceModel.current
-
-    var getScreenSize: String?
-    var aspectRatio: String?
-
-    static var screenSize: Float {
+    
+    private func deviceScreenSize() -> Float {
         switch self.deviceModel {
         case .iPhone4, .iPhone4S:                                               return 3.5
         case .iPodTouch1Gen, .iPodTouch2Gen, .iPodTouch3Gen, .iPodTouch4Gen:    return 3.5
@@ -35,5 +43,5 @@ struct Device {
         case .unknown, .simulator:                                              return 0
         }
     }
-
 }
+

--- a/Framework/Dotzu/Dotzu/Device.swift
+++ b/Framework/Dotzu/Dotzu/Device.swift
@@ -14,7 +14,7 @@ struct Device {
     var osVersion: String?
     var screenResolution: String!
     var aspectRatio: String?
-    var screenSize: Float!
+    var screenSize: Float = 0.0
     
     init() {
         self.screenResolution = self.deviceScreenResolution()

--- a/Framework/Dotzu/Dotzu/Device.swift
+++ b/Framework/Dotzu/Dotzu/Device.swift
@@ -10,7 +10,7 @@ import UIKit
 
 struct Device {
     var osVersion: String?
-    var screenResolution: String?
+    var screenResolution: String!
     let deviceModel: DeviceModel = DeviceModel.current
     
     var getScreenSize: String?

--- a/Framework/Dotzu/Dotzu/InformationsTableViewController.swift
+++ b/Framework/Dotzu/Dotzu/InformationsTableViewController.swift
@@ -17,7 +17,9 @@ class InformationsTableViewController: UITableViewController {
     @IBOutlet weak var labelScreenSize: UILabel!
     @IBOutlet weak var labelDeviceModel: UILabel!
     @IBOutlet weak var labelCrashCount: UILabel!
-
+    
+    var device: Device = Device()
+    
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
     }
@@ -39,8 +41,8 @@ class InformationsTableViewController: UITableViewController {
         labelBuildNumber.text = ApplicationInformation.buildNumber
         labelBundleName.text = ApplicationInformation.bundleName
 
-        labelScreenResolution.text = Device.screenResolution
-        labelScreenSize.text = "\(Device.screenSize)"
-        labelDeviceModel.text = "\(Device.deviceModel)"
+        labelScreenResolution.text = self.device.screenResolution
+        labelScreenSize.text = "\(self.device.screenSize)"
+        labelDeviceModel.text = "\(self.device.deviceModel)"
     }
 }


### PR DESCRIPTION
Device class is now more easy to mock.
What i did to accomplish that is just remove all the static variables from the class.
I also made the class more swift like.
Another good point is that now the `InformationsTableViewController` has his own device instance, and this makes it more easy to test, with a snapshot test for example, but also with UI tests, with mocked `Device` class