### PR TITLE
Make manager view optional

### DIFF
--- a/Example/ExampleDotzu/ExampleDotzu/AppDelegate.swift
+++ b/Example/ExampleDotzu/ExampleDotzu/AppDelegate.swift
@@ -16,7 +16,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+
+        let config = DotzuConfig()
+        // To show manager view comment (or change showManagerView = true) and restart
+        config.showManagerView = false
+        Dotzu.setUp(config: config)
         Dotzu.sharedManager.enable()
+
         return true
     }
 }

--- a/Example/ExampleDotzu/ExampleDotzu/AppDelegate.swift
+++ b/Example/ExampleDotzu/ExampleDotzu/AppDelegate.swift
@@ -17,17 +17,21 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
 
-        let config = DotzuConfig()
-        // To show manager view comment (or change showManagerView = true) and restart
-        config.showManagerView = false
-        Dotzu.setUp(config: config)
+        // Uncomment to use Dotzu without bubble head.
+        // Exapmple uses shake gesture to launch Dotzu Manager
+        /*
+         let config = DotzuConfig()
+         config.showManagerView = false
+         Dotzu.setUp(config: config)
+         */
+
         Dotzu.sharedManager.enable()
 
         return true
     }
 }
 
-// One of the way to show Dotzu logs view
+// One of the way to show Dotzu Manager
 #if DEBUG
 extension UIWindow {
 

--- a/Example/ExampleDotzu/ExampleDotzu/AppDelegate.swift
+++ b/Example/ExampleDotzu/ExampleDotzu/AppDelegate.swift
@@ -31,10 +31,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 #if DEBUG
 extension UIWindow {
 
-    override open var canBecomeFirstResponder: Bool {
-        return true
-    }
-
     override open func motionBegan(_ motion: UIEventSubtype, with event: UIEvent?) {
         if motion == .motionShake {
             if let controller = Dotzu.sharedManager.managerViewController() {

--- a/Example/ExampleDotzu/ExampleDotzu/AppDelegate.swift
+++ b/Example/ExampleDotzu/ExampleDotzu/AppDelegate.swift
@@ -26,3 +26,21 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 }
+
+// One of the way to show Dotzu logs view
+#if DEBUG
+extension UIWindow {
+
+    override open var canBecomeFirstResponder: Bool {
+        return true
+    }
+
+    override open func motionBegan(_ motion: UIEventSubtype, with event: UIEvent?) {
+        if motion == .motionShake {
+            if let controller = Dotzu.sharedManager.managerViewController() {
+                self.rootViewController?.present(controller, animated: true, completion: nil)
+            }
+        }
+    }
+}
+#endif

--- a/Framework/Dotzu/Dotzu/DotzuManager.swift
+++ b/Framework/Dotzu/Dotzu/DotzuManager.swift
@@ -8,10 +8,15 @@
 
 import UIKit
 
+public class DotzuConfig: NSObject {
+    public var showManagerView = true
+}
+
 public class Dotzu: NSObject {
     public static let sharedManager = Dotzu()
-    private var window: ManagerWindow
-    fileprivate let controller = ManagerViewController()
+    private var config: DotzuConfig = DotzuConfig()
+    private var window: ManagerWindow?
+    fileprivate var controller: ManagerViewController?
     private let cache = NSCache<AnyObject, AnyObject>()
     private let userDefault = UserDefaults.standard
     var displayedList = false
@@ -25,18 +30,22 @@ public class Dotzu: NSObject {
 
     public func enable() {
         initLogsManager()
-        self.window.rootViewController = self.controller
-        self.window.makeKeyAndVisible()
-        self.window.delegate = self
+        if self.config.showManagerView {
+            self.window = ManagerWindow(frame: UIScreen.main.bounds)
+            self.controller = ManagerViewController()
+        }
+        self.window?.rootViewController = self.controller
+        self.window?.makeKeyAndVisible()
+        self.window?.delegate = self
         LoggerNetwork.shared.enable = LogsSettings.shared.network
         Logger.shared.enable = true
         LoggerCrash.shared.enable = true
     }
 
     public func disable() {
-        self.window.rootViewController = nil
-        self.window.resignKey()
-        self.window.removeFromSuperview()
+        self.window?.rootViewController = nil
+        self.window?.resignKey()
+        self.window?.removeFromSuperview()
         Logger.shared.enable = false
         LoggerCrash.shared.enable = false
         LoggerNetwork.shared.enable = false
@@ -46,14 +55,22 @@ public class Dotzu: NSObject {
         session.protocolClasses?.insert(LoggerNetwork.self, at: 0)
     }
 
+    public class func setUp(config: DotzuConfig) {
+        sharedManager.config = config
+    }
+
+    public func managerViewController () -> UIViewController? {
+        let storyboard = UIStoryboard(name: "Manager", bundle: Bundle(for: ManagerViewController.self))
+        return storyboard.instantiateInitialViewController()
+    }
+    
     override init() {
-        self.window = ManagerWindow(frame: UIScreen.main.bounds)
         super.init()
     }
 }
 
 extension Dotzu: ManagerWindowDelegate {
     func isPointEvent(point: CGPoint) -> Bool {
-        return self.controller.shouldReceive(point: point)
+        return self.controller?.shouldReceive(point: point) ?? false
     }
 }

--- a/README.md
+++ b/README.md
@@ -39,9 +39,8 @@ Be careful to use Dotzu for development purpose only.
    }
 ```
 
-### Optional customization
-Using Dotzu without Manager Window (bubble head)
-You will need to use Dotzu.sharedManager.managerViewController() To launch Dotzu View.
+### Optional Customization
+Using Dotzu without Manager Bbubble Head. Use `Dotzu.sharedManager.managerViewController()` to launch Dotzu Manager.
 
 ```swift
     #if DEBUG

--- a/README.md
+++ b/README.md
@@ -39,6 +39,20 @@ Be careful to use Dotzu for development purpose only.
    }
 ```
 
+### Optional customization
+Using Dotzu without Manager Window (bubble head)
+You will need to use Dotzu.sharedManager.managerViewController() To launch Dotzu View.
+
+```swift
+    #if DEBUG
+    let config = DotzuConfig()
+    config.showManagerView = false
+    Dotzu.setUp(config: config)
+
+    Dotzu.sharedManager.enable()
+    #endif
+```
+
 ## Logs
 
 Dotzu override `print`, so you can use it and see your logs. otherwise, you can add level, and get more details (file, and line) about your logs. With the `Logger` class provided by the framework. Get new logs count on the badge, or *warning/error* notification on the bubble head.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Be careful to use Dotzu for development purpose only.
 ```
 
 ### Optional Customization
-Using Dotzu without Manager Bbubble Head. Use `Dotzu.sharedManager.managerViewController()` to launch Dotzu Manager.
+Using Dotzu without Manager Bubble Head. To launch Dotzu Manager use  `Dotzu.sharedManager.managerViewController()` .
 
 ```swift
     #if DEBUG


### PR DESCRIPTION
Thank you for all your work for awesome logging tool!

In this PR, I have added option to use Dotzu without Bubble Head. 

We are using Dotzu with some in-house debugging tools. We were looking to manage all the debugging tools at one place.

Summary:
- Made Manager window & controller optional
- Created Dotzu config to extend setup options in the future. 
- Opened access to ManagerViewController from DotzuManager
- Updated example with config
- Updated ReadMe to show usage of config

Thanks!