### PR TITLE
Feature/make bubble head optional

### DIFF
--- a/Example/ExampleDotzu/ExampleDotzu/AppDelegate.swift
+++ b/Example/ExampleDotzu/ExampleDotzu/AppDelegate.swift
@@ -14,9 +14,33 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+
+        // Customize Dotzu programmatically using LogSettings.
+        // Some of the LogSettings options are also available inside Dotzu Settings user interface.
+        //
+        // Following example shows how to use Dotzu without bubble head.
+        // Example uses shake gesture to launch Dotzu Manager
+        /*
+         // Set up LogSettings before enabling Dotzu
+         LogsSettings.shared.showBubbleHead = false
+         */
         Dotzu.sharedManager.enable()
+
         return true
     }
 }
+
+// One of the way to show Dotzu Manager
+#if DEBUG
+    extension UIWindow {
+
+        override open func motionBegan(_ motion: UIEventSubtype, with event: UIEvent?) {
+            if motion == .motionShake {
+                if let controller = Dotzu.sharedManager.viewController() {
+                    self.rootViewController?.present(controller, animated: true, completion: nil)
+                }
+            }
+        }
+    }
+#endif

--- a/Framework/Dotzu/Dotzu/DotzuManager.swift
+++ b/Framework/Dotzu/Dotzu/DotzuManager.swift
@@ -10,8 +10,8 @@ import UIKit
 
 public class Dotzu: NSObject {
     public static let sharedManager = Dotzu()
-    private var window: ManagerWindow
-    fileprivate let controller = ManagerViewController()
+    private var window: ManagerWindow?
+    fileprivate var controller: ManagerViewController?
     private let cache = NSCache<AnyObject, AnyObject>()
     private let userDefault = UserDefaults.standard
     var displayedList = false
@@ -24,19 +24,26 @@ public class Dotzu: NSObject {
     }
 
     public func enable() {
+
         initLogsManager()
-        self.window.rootViewController = self.controller
-        self.window.makeKeyAndVisible()
-        self.window.delegate = self
+
+        if LogsSettings.shared.showBubbleHead {
+            self.window = ManagerWindow(frame: UIScreen.main.bounds)
+            self.controller = ManagerViewController()
+        }
+        self.window?.rootViewController = self.controller
+        self.window?.makeKeyAndVisible()
+        self.window?.delegate = self
+
         LoggerNetwork.shared.enable = LogsSettings.shared.network
         Logger.shared.enable = true
         LoggerCrash.shared.enable = true
     }
 
     public func disable() {
-        self.window.rootViewController = nil
-        self.window.resignKey()
-        self.window.removeFromSuperview()
+        self.window?.rootViewController = nil
+        self.window?.resignKey()
+        self.window?.removeFromSuperview()
         Logger.shared.enable = false
         LoggerCrash.shared.enable = false
         LoggerNetwork.shared.enable = false
@@ -46,14 +53,18 @@ public class Dotzu: NSObject {
         session.protocolClasses?.insert(LoggerNetwork.self, at: 0)
     }
 
+    public func viewController () -> UIViewController? {
+        let storyboard = UIStoryboard(name: "Manager", bundle: Bundle(for: ManagerViewController.self))
+        return storyboard.instantiateInitialViewController()
+    }
+
     override init() {
-        self.window = ManagerWindow(frame: UIScreen.main.bounds)
         super.init()
     }
 }
 
 extension Dotzu: ManagerWindowDelegate {
     func isPointEvent(point: CGPoint) -> Bool {
-        return self.controller.shouldReceive(point: point)
+        return self.controller?.shouldReceive(point: point) ?? false
     }
 }

--- a/Framework/Dotzu/Dotzu/LogsSettings.swift
+++ b/Framework/Dotzu/Dotzu/LogsSettings.swift
@@ -37,6 +37,11 @@ public class LogsSettings {
             UserDefaults.standard.set(fileInfo, forKey: "networkLoggerEnabled")
         }
     }
+    public var showBubbleHead: Bool {
+        didSet {
+            UserDefaults.standard.set(showBubbleHead, forKey: "showBubbleHead")
+        }
+    }
 
     init() {
         overridePrint = UserDefaults.standard.bool2(forKey: "enableOverridePrint")
@@ -44,5 +49,6 @@ public class LogsSettings {
         fileInfo = UserDefaults.standard.bool2(forKey: "fileInfoDisplayed")
         date = UserDefaults.standard.bool2(forKey: "dateDisplayed")
         network = UserDefaults.standard.bool2(forKey: "networkLoggerEnabled")
+        showBubbleHead = UserDefaults.standard.bool2(forKey: "showBubbleHead")
     }
 }

--- a/Framework/Dotzu/Dotzu/LogsSettings.swift
+++ b/Framework/Dotzu/Dotzu/LogsSettings.swift
@@ -8,31 +8,31 @@
 
 import Foundation
 
-class LogsSettings {
+public class LogsSettings {
 
-    static let shared = LogsSettings()
+    public static let shared = LogsSettings()
 
-    var overridePrint: Bool {
+    public var overridePrint: Bool {
         didSet {
             UserDefaults.standard.set(overridePrint, forKey: "enableOverridePrint")
         }
     }
-    var resetLogsStart: Bool {
+    public var resetLogsStart: Bool {
         didSet {
             UserDefaults.standard.set(resetLogsStart, forKey: "resetLogsStart")
         }
     }
-    var fileInfo: Bool {
+    public var fileInfo: Bool {
         didSet {
             UserDefaults.standard.set(fileInfo, forKey: "fileInfoDsisplayed")
         }
     }
-    var date: Bool {
+    public var date: Bool {
         didSet {
             UserDefaults.standard.set(fileInfo, forKey: "dateDisplayed")
         }
     }
-    var network: Bool {
+    public var network: Bool {
         didSet {
             UserDefaults.standard.set(fileInfo, forKey: "networkLoggerEnabled")
         }


### PR DESCRIPTION
In this PR, I have added option to use Dotzu without Bubble Head and configure LogSettings programmatically. 

Why?
* We are using Dotzu with some in-house debugging tools. We were looking to manage all the debugging tools at one place.

Summary of changes:

* Made LogSettings public and added var to track show/hide bubble head
* Made Manager window & controller optional
* Opened access to ManagerViewController from DotzuManager
* Updated example with LogSettings

Notes: 

* Why Bubble head setting is not added to Dotzu Settings?
** I am working on another PR, which adds more options to LogSettings and it may get cumbersome to maintain. 

Thanks a lot for your time.

Cheers!
